### PR TITLE
Fixed TalonFollowerInitialize to use input parameter 

### DIFF
--- a/2021/Robot2021/src/main/cpp/subsystems/Drivetrain.cpp
+++ b/2021/Robot2021/src/main/cpp/subsystems/Drivetrain.cpp
@@ -202,11 +202,11 @@ void Drivetrain::TalonMasterInitialize(WPI_BaseMotorController &motor)
 
 void Drivetrain::TalonFollowerInitialize(WPI_BaseMotorController &motor, int master)
 {
-    m_motorL2.Set(ControlMode::Follower, master);
-    m_motorL2.SetInverted(InvertType::FollowMaster);
-    m_motorL2.SetNeutralMode(NeutralMode::Coast);
-    m_motorL2.ConfigVoltageCompSaturation(12.0, kCANTimeout);
-    m_motorL2.EnableVoltageCompensation(true);
+    motor.Set(ControlMode::Follower, master);
+    motor.SetInverted(InvertType::FollowMaster);
+    motor.SetNeutralMode(NeutralMode::Coast);
+    motor.ConfigVoltageCompSaturation(12.0, kCANTimeout);
+    motor.EnableVoltageCompensation(true);
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Instead of incorrectly addressing motorL2. By addressing motor L2, it gets initialized to follow L1, and then re-initialized to follow R3. This causes a fight in the left side transmission, and the right side only uses motor R3.