### PR TITLE
Minor cleanup of carriage returns and tabs in spdlog output strings

### DIFF
--- a/2021/Robot2021/src/main/cpp/Robot.cpp
+++ b/2021/Robot2021/src/main/cpp/Robot.cpp
@@ -110,7 +110,7 @@ void Robot::TestPeriodic() {}
 void Robot::RobotFaultDump(void)
 {
     // Print out talon SRX faults and clear sticky ones
-    std::printf("2135: %s --------------\n", "FAULT DUMPS");
+    spdlog::info("----- DUMP FAULTS --------------");
 
     RobotContainer *robotContainer = RobotContainer::GetInstance();
     robotContainer->m_drivetrain.FaultDump();

--- a/2021/Robot2021/src/main/cpp/frc2135/TalonUtils.cpp
+++ b/2021/Robot2021/src/main/cpp/frc2135/TalonUtils.cpp
@@ -38,7 +38,7 @@ namespace frc2135
         deviceID = talon.GetDeviceID();
         if ((error = talon.GetLastError()) != OKAY)
         {
-            spdlog::error(" {} Motor {} GetDeviceID error - {}", subsystem, name, error);
+            spdlog::error("{} Motor {} GetDeviceID error - {}", subsystem, name, error);
             return error;
         }
 
@@ -124,7 +124,7 @@ namespace frc2135
         StickyFaults stickyFaults;
 
         // Print out Talon faults and clear sticky ones
-        spdlog::info("{} -------------- {}", "Talon ", talonName);
+        spdlog::info("Talon -------------- {}", talonName);
 
         // Check Talon by getting device ID and validating firmware versions
         talon.GetDeviceID();
@@ -274,7 +274,7 @@ namespace frc2135
             if (pigeonValid)
             {
                 spdlog::info(
-                    "2135: %s %s ID %d ver %u.%u is RESPONSIVE and INITIALIZED (error %d)\n",
+                    "{} {} ID {} ver {}.{} is RESPONSIVE and INITIALIZED (error {})",
                     subsystem,
                     name,
                     deviceID,
@@ -301,16 +301,17 @@ namespace frc2135
 
     void TalonUtils::PigeonIMUFaultDump(const char *pigeonName, PigeonIMU &pigeonPtr)
     {
+        int deviceID = 0;
         int fwVersion = 0;
         ErrorCode error = OKAY;
         PigeonIMU_Faults faults;
         PigeonIMU_StickyFaults stickyFaults;
 
         // Print out PigeonIMU faults and clear sticky ones
-        spdlog::info("{} -------------- {}", "PigeonIMU ", pigeonName);
+        spdlog::info("PigeonIMU -------------- {}", pigeonName);
 
         // Check PigeonIMU by getting device ID and validating firmware versions
-        pigeonPtr.GetDeviceNumber();
+        deviceID = pigeonPtr.GetDeviceNumber();
         if ((error = pigeonPtr.GetLastError()) != OKAY)
         {
             spdlog::error("PigeonIMU Gyro GetDeviceID error - {}", error);
@@ -341,7 +342,7 @@ namespace frc2135
 
         if (faults.HasAnyFault())
         {
-            spdlog::error("{} {} ID {} has a FAULT - {}", "DT", "PigeonIMU", 2, faults.ToBitfield());
+            spdlog::error("PigeonIMU ID {} has a FAULT - {}", deviceID, faults.ToBitfield());
         }
         else
         {

--- a/2021/Robot2021/src/main/cpp/subsystems/Drivetrain.cpp
+++ b/2021/Robot2021/src/main/cpp/subsystems/Drivetrain.cpp
@@ -658,7 +658,7 @@ bool Drivetrain::MoveAlignTurnIsFinished(double angle)
 
     if (abs(m_alignTurnError) < m_alignTurnTolerance)
     {
-        spdlog::info("DTAT - Error Within Tolerance\n");
+        spdlog::info("DTAT - Error Within Tolerance");
         isFinished = true;
     }
 

--- a/2021/Robot2021/src/main/cpp/subsystems/Pneumatics.cpp
+++ b/2021/Robot2021/src/main/cpp/subsystems/Pneumatics.cpp
@@ -69,13 +69,13 @@ void Pneumatics::Initialize(void)
 void Pneumatics::FaultDump(void)
 {
     // Print out PCM faults and clear sticky ones
-    spdlog::warn(" -------------- {}", "PCM FAULTS");
+    spdlog::info("----- PCM FAULTS --------------");
 
     if (m_pcm.GetCompressorCurrentTooHighStickyFault())
-        spdlog::warn("\tCurrentTooHighFault");
+        spdlog::warn("CurrentTooHighFault");
     if (m_pcm.GetCompressorNotConnectedFault())
-        spdlog::warn("\tCompressorNotConnectedFault");
+        spdlog::warn("CompressorNotConnectedFault");
     if (m_pcm.GetCompressorShortedFault())
-        spdlog::warn("\tCompressorShortedFault");
+        spdlog::warn("CompressorShortedFault");
     m_pcm.ClearAllPCMStickyFaults();
 }

--- a/2021/Robot2021/src/main/cpp/subsystems/Power.cpp
+++ b/2021/Robot2021/src/main/cpp/subsystems/Power.cpp
@@ -87,7 +87,7 @@ void Power::Initialize(void)
 void Power::FaultDump(void)
 {
     // Print out PDP faults and clear sticky ones
-    spdlog::info("PDP FAULTS --------------");
+    spdlog::info("----- PDP FAULTS --------------");
     spdlog::info("Temperature      {}", m_pdp.GetTemperature());
     spdlog::info("Input Voltage    {}", m_pdp.GetVoltage());
     for (int i = 0; i <= 15; i++)


### PR DESCRIPTION
Removed some leftover \n and \t characters from printfs and completed a few missing conversions to spdlog.